### PR TITLE
Add filtering engine and mock scraper modules

### DIFF
--- a/scrapers/indeed_scraper.py
+++ b/scrapers/indeed_scraper.py
@@ -1,0 +1,24 @@
+from datetime import date
+
+
+def fetch_jobs():
+    return [
+        {
+            "title": "Strategic Investment Manager",
+            "company": "UK Infrastructure Bank",
+            "location": "London",
+            "description": "Leads strategic finance initiatives...",
+            "red_flags": "UK nationals only",
+            "link": "https://example.com/job-1",
+            "posted_date": str(date.today())
+        },
+        {
+            "title": "ESG Audit Officer",
+            "company": "Generic Bank",
+            "location": "Remote",
+            "description": "Internal audit responsibilities...",
+            "red_flags": "ACA required",
+            "link": "https://example.com/job-2",
+            "posted_date": str(date.today())
+        }
+    ]

--- a/utils/filter_engine.py
+++ b/utils/filter_engine.py
@@ -1,0 +1,28 @@
+import json
+
+
+def load_preferences(path="preferences.json"):
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def filter_jobs(jobs, preferences):
+    filtered = []
+    for job in jobs:
+        title = job["title"].lower()
+        org = job["company"].lower()
+        description = job["description"].lower()
+        red_flags = job.get("red_flags", "").lower()
+
+        if any(term.lower() in title for term in preferences["exclusion_terms"]["title"]):
+            continue
+        if any(term.lower() in org for term in preferences["exclusion_terms"]["organization"]):
+            continue
+        if any(term.lower() in red_flags for term in preferences["exclusion_terms"]["red_flags"]):
+            continue
+        if preferences["location"].lower() not in job["location"].lower():
+            continue
+
+        filtered.append(job)
+
+    return filtered


### PR DESCRIPTION
## Summary
- add filtering utilities for future job data parsing
- include a mock Indeed scraper

## Testing
- `python -m py_compile main.py utils/filter_engine.py scrapers/indeed_scraper.py`

------
https://chatgpt.com/codex/tasks/task_e_68447779498c8321bd0a1c9371a72023