### PR TITLE
Fix: Add root route for Render health check

### DIFF
--- a/main.py
+++ b/main.py
@@ -15,6 +15,11 @@ app = FastAPI(
     }]
 )
 
+
+@app.get("/")
+def root():
+    return {"message": "Lisa Job GPT Backend is live 🚀"}
+
 class Job(BaseModel):
     title: str
     company: str


### PR DESCRIPTION
## Summary
- add `/` endpoint for Render health check

## Testing
- `python -m py_compile main.py`
- `uvicorn main:app --port 8000 --host 127.0.0.1` and `curl http://127.0.0.1:8000/`

------
https://chatgpt.com/codex/tasks/task_e_6844875fc874832192736795386c9138