### PR TITLE
Switch job scraper to RSS feed

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ uvicorn
 pydantic
 requests
 beautifulsoup4
+feedparser


### PR DESCRIPTION
## Summary
- update job scraper to use the Civil Service RSS feed
- add feedparser dependency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844e4e89c2483218a1111f636c6afdb