### PR TITLE
Improve Civil Service scraping

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,5 @@
-from fastapi import FastAPI
-from scrapers.indeed_scraper import fetch_jobs
+from fastapi import FastAPI, Query
+from scrapers.civil_service_scraper import fetch_jobs
 
 app = FastAPI(
     title="Lisa's Strategic Job Scanner",
@@ -19,6 +19,6 @@ def root():
     return {"message": "Lisa GPT Backend is live!"}
 
 @app.get("/jobs")
-def get_jobs():
+def get_jobs(keyword: str | None = Query(None), location: str | None = Query(None)):
     """Return job listings scraped from the Civil Service site."""
-    return fetch_jobs()
+    return fetch_jobs(keyword, location)

--- a/scrapers/civil_service_scraper.py
+++ b/scrapers/civil_service_scraper.py
@@ -1,0 +1,47 @@
+import requests
+from bs4 import BeautifulSoup
+from typing import List, Dict, Optional
+
+
+def fetch_jobs(keyword: Optional[str] = None, location: Optional[str] = None) -> List[Dict[str, str]]:
+    """Scrape Civil Service job listings using the search form."""
+    search_url = "https://www.civilservicejobs.service.gov.uk/csr/index.cgi"
+    params = {
+        "SID": "Y2FudGVyaWRhdGVfdXNlcg==",
+        "txtKeyword": keyword or "",
+        "txtLocation": location or "",
+        "order": "1",
+        "x": "0",
+        "y": "0",
+    }
+
+    response = requests.get(search_url, params=params)
+    response.raise_for_status()
+    soup = BeautifulSoup(response.text, "html.parser")
+
+    jobs: List[Dict[str, str]] = []
+    postings = soup.select("div.jobSummary")
+    for post in postings:
+        title_tag = post.find("h3")
+        title = title_tag.get_text(strip=True) if title_tag else "No title"
+
+        location_tag = post.select_one(".jobLocation")
+        loc = location_tag.get_text(strip=True) if location_tag else "Unknown"
+
+        salary_tag = post.select_one(".jobSalary")
+        salary = salary_tag.get_text(strip=True) if salary_tag else "N/A"
+
+        link_tag = post.find("a", href=True)
+        link = (
+            f"https://www.civilservicejobs.service.gov.uk{link_tag['href']}"
+            if link_tag else "N/A"
+        )
+
+        jobs.append({
+            "title": title,
+            "location": loc,
+            "salary": salary,
+            "link": link,
+        })
+
+    return jobs


### PR DESCRIPTION
## Summary
- add new scraper for Civil Service search form
- accept keyword and location query params in `/jobs`

## Testing
- `python -m pip install -r requirements.txt`
- `python -m py_compile main.py scrapers/civil_service_scraper.py`
- `python - <<'PY'
import scrapers.civil_service_scraper as s
try:
    jobs = s.fetch_jobs(keyword='finance', location='london')
    print('jobs:', len(jobs))
except Exception as e:
    print('error:', e)
PY
`

------
https://chatgpt.com/codex/tasks/task_e_6844e98092ac832198a49c71706a1b26