### PR TITLE
Add JobSpy scraper integration

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,5 @@
 from fastapi import FastAPI, Query
-from scrapers.civil_service_scraper import fetch_jobs
+from scrapers.jobspy_scraper import fetch_jobs
 
 app = FastAPI(
     title="Lisa's Strategic Job Scanner",

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pydantic
 requests
 beautifulsoup4
 feedparser
+jobspy==0.29.0

--- a/scrapers/jobspy_scraper.py
+++ b/scrapers/jobspy_scraper.py
@@ -1,0 +1,32 @@
+from jobspy import scrape_jobs
+from datetime import date
+
+
+def fetch_jobs(keyword="policy", location="London"):
+    jobs = scrape_jobs(
+        site_name=["indeed", "linkedin", "glassdoor"],
+        search_term=keyword,
+        location=location,
+        results_wanted=20,
+        hours_old=336,  # past 14 days
+        country_indeed="UK",
+    )
+
+    jobs = jobs.fillna("")  # Fill empty fields
+
+    results = []
+
+    for _, row in jobs.iterrows():
+        results.append(
+            {
+                "title": row["title"],
+                "organization": row["company_name"],
+                "location": row["location"],
+                "description": row["description"],
+                "red_flags": "",
+                "link": row["job_url"],
+                "posted_date": str(date.today()),
+            }
+        )
+
+    return results


### PR DESCRIPTION
## Summary
- install jobspy package
- add scraper for jobspy
- update FastAPI app to use JobSpy

## Testing
- `pip install jobspy==0.29.0`
- `python -m py_compile main.py scrapers/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6845083289e48321be4bc013beadef18