### PR TITLE
Fix merge: use civil service scraper with fallback

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI, Query
-from scrapers.jobspy_scraper import fetch_jobs
+from scrapers.civil_service_scraper import fetch_jobs as fetch_civil_service_jobs
+from scrapers.indeed_scraper import fetch_jobs as fetch_fallback_jobs
 
 app = FastAPI(
     title="Lisa's Strategic Job Scanner",
@@ -28,5 +29,11 @@ def get_jobs(
         default="london", description="Location to filter by (e.g. 'London')"
     ),
 ):
-    """Return job listings scraped from the Civil Service site."""
-    return fetch_jobs(keyword=keyword, location=location)
+    """Return job listings from the Civil Service site.
+
+    Falls back to a simpler RSS-based scraper if the primary scraper fails.
+    """
+    try:
+        return fetch_civil_service_jobs(keyword=keyword, location=location)
+    except Exception:
+        return fetch_fallback_jobs(keyword=keyword, location=location)

--- a/scrapers/indeed_scraper.py
+++ b/scrapers/indeed_scraper.py
@@ -1,9 +1,11 @@
 import feedparser
 
 
-def fetch_jobs(location: str = None):
+def fetch_jobs(keyword: str | None = None, location: str | None = None):
     """Fetch job listings from the Civil Service RSS feed.
-    Optionally filters by keyword if `location` is provided.
+
+    Both ``keyword`` and ``location`` are optional and are used to filter
+    the returned entries if provided.
     """
     url = (
         "https://www.civilservicejobs.service.gov.uk/rss/civilservice/alljobs.rss"
@@ -12,14 +14,20 @@ def fetch_jobs(location: str = None):
 
     jobs = []
     for entry in feed.entries:
-        if location and location.lower() not in entry.title.lower():
+        title = entry.title
+        summary = entry.get("summary", "")
+
+        if keyword and keyword.lower() not in title.lower() and keyword.lower() not in summary.lower():
             continue
+        if location and location.lower() not in title.lower():
+            continue
+
         jobs.append(
             {
-                "title": entry.title,
+                "title": title,
                 "link": entry.link,
                 "published": entry.published,
-                "summary": entry.get("summary", ""),
+                "summary": summary,
             }
         )
     return jobs


### PR DESCRIPTION
## Summary
- import Civil Service scraper
- add fallback to Indeed RSS scraper
- allow keyword & location filters for RSS scraper

## Testing
- `python -m py_compile main.py scrapers/*.py`
- `python - <<'PY'
from scrapers.civil_service_scraper import fetch_jobs
try:
    jobs = fetch_jobs(keyword='policy', location='london')
    print('jobs returned', len(jobs))
except Exception as e:
    print('error', e)
PY`

------
https://chatgpt.com/codex/tasks/task_e_6844fb2c3360832193380ccd4304abc9