### PR TITLE
Integrate Civil Service scraper env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,8 @@ uvicorn main:app --reload
 
 Then open `http://localhost:8000/docs` for the interactive API docs.
 
+Set the `CIVIL_SERVICE_SID` environment variable with the encoded SID from the
+Civil Service Jobs website if you need to override the default. The application
+falls back to `YXBpX3NlYXJjaF9mb3Jt` when the variable is not provided.
+
 The `/jobs` endpoint accepts optional `keyword` and `location` query parameters and defaults to `policy` and `london` if omitted.

--- a/scrapers/civil_service_scraper.py
+++ b/scrapers/civil_service_scraper.py
@@ -1,11 +1,15 @@
+import os
 import requests
 from bs4 import BeautifulSoup
 from datetime import date
 
+# Allow the Civil Service search SID to be configured via environment variable
+SID = os.getenv("CIVIL_SERVICE_SID", "YXBpX3NlYXJjaF9mb3Jt")
+
 def fetch_jobs(keyword="policy", location="london"):
     url = "https://www.civilservicejobs.service.gov.uk/csr/index.cgi"
     params = {
-        "SID": "YXBpX3NlYXJjaF9mb3Jt",
+        "SID": SID,
         "jcode": "",
         "txtSearch": keyword,
         "postcode": location,


### PR DESCRIPTION
## Summary
- read optional `CIVIL_SERVICE_SID` environment variable in `civil_service_scraper`
- document `CIVIL_SERVICE_SID` in README

## Testing
- `python -m py_compile main.py scrapers/*.py utils/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68450e02b1c483218dd111a71dca4159