### PR TITLE
Add job scanning and filtering endpoints

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,70 +1,27 @@
-from fastapi import FastAPI, Query
-from pydantic import BaseModel
-from typing import List
-import datetime
-import requests
-from bs4 import BeautifulSoup
+from fastapi import FastAPI
+from typing import Optional
 
-app = FastAPI(
-    title="Lisa's Strategic Job Scanner",
-    description="Filters public sector and multilateral roles based on Lisa Mouslech’s career direction.",
-    version="1.0.0",
-    servers=[{
-        "url": "https://lisa-job-gpt-backend.onrender.com",
-        "description": "Live Render server"
-    }]
-)
-
-class Job(BaseModel):
-    title: str
-    company: str
-    location: str
-    description: str
-    requirements: List[str]
-    skills: List[str]
-    fit_score: int
-    why_fit: str
-    red_flags: str
-    link: str
-    salary_range: str
-    posted_date: str
+from scrapers.indeed_scraper import fetch_jobs
+from utils.filter_engine import filter_jobs, load_preferences
 
 
-def fetch_jobs(location: str = "London") -> List[Job]:
-    """Scrape public policy jobs from Indeed for the given location."""
-    url = f"https://uk.indeed.com/jobs?q=public+policy&l={location}"
-    headers = {"User-Agent": "Mozilla/5.0"}
-    resp = requests.get(url, headers=headers, timeout=10)
-    soup = BeautifulSoup(resp.text, "html.parser")
+app = FastAPI(title="Lisa's Strategic Job Scanner")
 
-    jobs = []
-    for card in soup.select(".job_seen_beacon")[:10]:
-        try:
-            title = card.select_one("h2.jobTitle").get_text(strip=True)
-            company = card.select_one(".companyName").get_text(strip=True)
-            link = "https://uk.indeed.com" + card.select_one("a")["href"]
 
-            jobs.append(
-                Job(
-                    title=title,
-                    company=company,
-                    location=location,
-                    description="",
-                    requirements=[],
-                    skills=[],
-                    fit_score=0,
-                    why_fit="",
-                    red_flags="",
-                    link=link,
-                    salary_range="",
-                    posted_date=str(datetime.date.today()),
-                )
-            )
-        except Exception:
-            continue
-    return jobs
+@app.get("/")
+def root():
+    return {"message": "Lisa Job GPT Backend is live 🚀"}
 
-@app.get("/scan-roles/", response_model=List[Job])
-def scan_roles(location: str = Query("London")):
-    """Return recent public policy jobs scraped from Indeed."""
-    return fetch_jobs(location)
+
+@app.get("/scan-roles")
+def scan_roles(location: Optional[str] = None):
+    """Return job listings filtered by user preferences."""
+    preferences = load_preferences()
+    jobs = fetch_jobs()
+
+    if location:
+        preferences["location"] = location.lower()
+
+    filtered = filter_jobs(jobs, preferences)
+    return filtered
+

--- a/preferences.json
+++ b/preferences.json
@@ -1,0 +1,8 @@
+{
+  "location": "london",
+  "exclusion_terms": {
+    "title": ["intern", "assistant"],
+    "organization": ["bank", "insurance"],
+    "red_flags": ["clearance", "unpaid", "commission"]
+  }
+}

--- a/scrapers/indeed_scraper.py
+++ b/scrapers/indeed_scraper.py
@@ -4,21 +4,21 @@ from datetime import date
 def fetch_jobs():
     return [
         {
-            "title": "Strategic Investment Manager",
-            "company": "UK Infrastructure Bank",
-            "location": "London",
-            "description": "Leads strategic finance initiatives...",
-            "red_flags": "UK nationals only",
-            "link": "https://example.com/job-1",
+            "title": "Policy Analyst",
+            "organization": "Department of Energy",
+            "description": "Climate strategy and green finance...",
+            "location": "london",
+            "red_flags": "",
+            "link": "https://example.com/job1",
             "posted_date": str(date.today())
         },
         {
-            "title": "ESG Audit Officer",
-            "company": "Generic Bank",
-            "location": "Remote",
-            "description": "Internal audit responsibilities...",
-            "red_flags": "ACA required",
-            "link": "https://example.com/job-2",
+            "title": "Senior Analyst",
+            "organization": "UK Finance",
+            "description": "Public sector finance, ESG policy...",
+            "location": "remote",
+            "red_flags": "requires UK gov clearance",
+            "link": "https://example.com/job2",
             "posted_date": str(date.today())
         }
     ]

--- a/utils/filter_engine.py
+++ b/utils/filter_engine.py
@@ -2,25 +2,25 @@ import json
 
 
 def load_preferences(path="preferences.json"):
-    with open(path, "r", encoding="utf-8") as f:
+    with open(path, encoding="utf-8") as f:
         return json.load(f)
 
 
 def filter_jobs(jobs, preferences):
     filtered = []
+    red_flags = preferences["exclusion_terms"]["red_flags"]
     for job in jobs:
         title = job["title"].lower()
-        org = job["company"].lower()
-        description = job["description"].lower()
-        red_flags = job.get("red_flags", "").lower()
+        org = job["organization"].lower()
+        red_flag_text = job.get("red_flags", "").lower()
 
-        if any(term.lower() in title for term in preferences["exclusion_terms"]["title"]):
+        if any(term in title for term in preferences["exclusion_terms"]["title"]):
             continue
-        if any(term.lower() in org for term in preferences["exclusion_terms"]["organization"]):
+        if any(term in org for term in preferences["exclusion_terms"]["organization"]):
             continue
-        if any(term.lower() in red_flags for term in preferences["exclusion_terms"]["red_flags"]):
+        if any(term in red_flag_text for term in red_flags):
             continue
-        if preferences["location"].lower() not in job["location"].lower():
+        if preferences["location"] not in job["location"].lower():
             continue
 
         filtered.append(job)


### PR DESCRIPTION
## Summary
- add preferences json for job scanning rules
- implement FastAPI app with root and scan-roles endpoints
- create realistic job fetcher mock
- update filter engine to use organization field

## Testing
- `python -m pip install -r requirements.txt`
- `uvicorn main:app --port 8000 --host 0.0.0.0 --log-level warning &`
- `curl -s http://localhost:8000/`
- `curl -s http://localhost:8000/scan-roles | jq .`


------
https://chatgpt.com/codex/tasks/task_e_684487cfc45083218d5beb5edf6b363b