### PR TITLE
Integrate Civil Service scraper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Lisa Job GPT Backend
 
-This FastAPI application exposes an endpoint for scanning public policy roles. It scrapes Indeed for the latest postings in a given location.
+This FastAPI application exposes an endpoint for scanning public policy roles. It scrapes the Civil Service Jobs site for the latest postings in a given location.
 
 ## Running locally
 
@@ -10,3 +10,9 @@ uvicorn main:app --reload
 ```
 
 Then open `http://localhost:8000/docs` for the interactive API docs.
+
+### Environment variables
+
+Set `CIVIL_SERVICE_SID` to the SID value from a working Civil Service Jobs
+search URL. If this variable is missing, the scraper logs an error and returns
+no results.

--- a/main.py
+++ b/main.py
@@ -1,5 +1,5 @@
-from fastapi import FastAPI
-from scrapers.indeed_scraper import fetch_jobs
+from fastapi import FastAPI, Query
+from scrapers.civil_service_scraper import fetch_jobs
 
 app = FastAPI(
     title="Lisa's Strategic Job Scanner",
@@ -13,12 +13,17 @@ app = FastAPI(
     ]
 )
 
+
 @app.get("/")
 def root():
     """Health check route for Render."""
     return {"message": "Lisa GPT Backend is live!"}
 
+
 @app.get("/jobs")
-def get_jobs():
+def get_jobs(
+    keyword: str = Query("", description="Keyword to search for"),
+    location: str = Query("", description="Location filter"),
+):
     """Return job listings scraped from the Civil Service site."""
-    return fetch_jobs()
+    return fetch_jobs(keyword=keyword, location=location)

--- a/scrapers/civil_service_scraper.py
+++ b/scrapers/civil_service_scraper.py
@@ -1,0 +1,87 @@
+import logging
+import os
+from typing import List
+from urllib.parse import urljoin
+
+import requests
+from bs4 import BeautifulSoup
+
+BASE_URL = "https://www.civilservicejobs.service.gov.uk/csr/index.cgi"
+# SID value is required for successful requests. Set via environment variable.
+SID = os.getenv("CIVIL_SERVICE_SID")
+
+
+def fetch_jobs(keyword: str = "", location: str = "") -> List[dict]:
+    """Scrape Civil Service Jobs listings.
+
+    The site requires a session identifier (SID). Provide it via the
+    ``CIVIL_SERVICE_SID`` environment variable.
+    """
+    if not SID:
+        logging.error("CIVIL_SERVICE_SID is not set")
+        return []
+
+    params = {
+        "SID": SID,
+        "txtKeyword": keyword,
+        "txtLocation": location,
+        "search_page": 1,
+        "order": 1,
+    }
+
+    headers = {
+        "User-Agent": (
+            "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+            "(KHTML, like Gecko) Chrome/118.0 Safari/537.36"
+        )
+    }
+
+    try:
+        response = requests.get(BASE_URL, params=params, headers=headers, timeout=10)
+        response.raise_for_status()
+    except requests.RequestException as exc:
+        logging.error("Request failed: %s", exc)
+        return []
+
+    soup = BeautifulSoup(response.text, "html.parser")
+    jobs = []
+    for box in soup.select("div[class*=search-results-job-box]"):
+        title_link = box.select_one(".search-results-job-box-title a")
+        if not title_link:
+            continue
+
+        job = {
+            "title": title_link.get_text(strip=True),
+            "url": urljoin(BASE_URL, title_link.get("href", "")),
+            "location": "",
+            "salary": "",
+            "department": "",
+            "closing_date": "",
+            "ref_code": "",
+        }
+
+        loc_el = box.select_one(".search-results-job-box-location")
+        if loc_el:
+            job["location"] = loc_el.get_text(strip=True)
+
+        sal_el = box.select_one(".search-results-job-box-salary")
+        if sal_el:
+            job["salary"] = sal_el.get_text(strip=True)
+
+        dept_el = box.select_one(".search-results-job-box-department")
+        if dept_el:
+            job["department"] = dept_el.get_text(strip=True)
+
+        close_el = box.select_one(".search-results-job-box-closingdate")
+        if close_el:
+            job["closing_date"] = close_el.get_text(strip=True)
+
+        ref_el = box.select_one(".search-results-job-box-refcode")
+        if ref_el:
+            job["ref_code"] = ref_el.get_text(strip=True)
+
+        jobs.append(job)
+
+    if not jobs:
+        logging.info("No jobs found for keyword: %s", keyword)
+    return jobs


### PR DESCRIPTION
## Summary
- add environment variable for SID and update README docs
- expose query params in FastAPI using `Query`
- send headers while scraping Civil Service listings
- handle missing SID value in scraper

## Testing
- `python -m py_compile main.py scrapers/*.py utils/filter_engine.py`
- `pip install -r requirements.txt`
- `python - <<'PY'
from scrapers.civil_service_scraper import fetch_jobs
print('fetching...')
jobs = fetch_jobs(keyword="policy", location="london")
print('jobs returned', len(jobs))
if jobs:
    print(jobs[0].keys())
PY`


------
https://chatgpt.com/codex/tasks/task_e_6844ea9c6e5083219b9bbd62905e69d7