### PR TITLE
Fix jobspy import by installing python-jobspy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.venv/
+__pycache__/
+*.py[cod]
+*.egg-info/
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ pydantic
 requests
 beautifulsoup4
 feedparser
-jobspy==0.29.0
+python-jobspy==1.1.80


### PR DESCRIPTION
## Summary
- add `.gitignore` to ignore virtualenv and caches
- use `python-jobspy` package instead of obsolete `jobspy`

## Testing
- `pip install -r requirements.txt`
- `python main.py`

------
https://chatgpt.com/codex/tasks/task_e_6845609ce8648321b49c613c0a398ee3