### PR TITLE
Fix organization extraction in jobspy scraper

### DIFF
--- a/scrapers/jobspy_scraper.py
+++ b/scrapers/jobspy_scraper.py
@@ -20,7 +20,9 @@ def fetch_jobs(keyword="policy", location="London"):
         results.append(
             {
                 "title": row["title"],
-                "organization": row["company_name"],
+                "organization": row.get("company_name")
+                or row.get("company")
+                or "Unknown",
                 "location": row["location"],
                 "description": row["description"],
                 "red_flags": "",


### PR DESCRIPTION
## Summary
- handle missing company_name field from jobspy result

## Testing
- `python codex/tasks/test_jobspy_import.py`


------
https://chatgpt.com/codex/tasks/task_e_68459da955088321bf6a9fdfa2fa17b4