### PR TITLE
Add pagination to Civil Service job listings

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,4 @@ Set the `CIVIL_SERVICE_SID` environment variable with the encoded SID from the
 Civil Service Jobs website if you need to override the default. The application
 falls back to `YXBpX3NlYXJjaF9mb3Jt` when the variable is not provided.
 
-The `/jobs` endpoint accepts optional `keyword` and `location` query parameters and defaults to `policy` and `london` if omitted.
+The `/jobs` endpoint accepts optional `keyword` and `location` query parameters and defaults to `policy` and `london` if omitted. Pagination is supported using `limit` and `offset` parameters which default to `15` and `0` respectively.

--- a/main.py
+++ b/main.py
@@ -34,12 +34,36 @@ def get_jobs(
         default="jobspy",
         description="Data source ('jobspy' or 'civil_service')",
     ),
+    limit: int = Query(
+        default=15,
+        description="Maximum number of results to return",
+    ),
+    offset: int = Query(
+        default=0,
+        description="Number of results to skip before returning data",
+    ),
 ):
-    """Return job listings from either JobSpy or the Civil Service site."""
+    """Return job listings from either JobSpy or the Civil Service site.
+
+    Parameters
+    ----------
+    keyword: str
+        Search keyword to filter results.
+    location: str
+        City or region to search within.
+    source: str
+        Data source to use, either ``jobspy`` or ``civil_service``.
+    limit: int
+        Maximum number of results to return (default ``15``).
+    offset: int
+        Number of results to skip before starting the slice (default ``0``).
+    """
     if source == "jobspy":
         return fetch_jobspy_jobs(keyword=keyword, location=location)
 
     try:
-        return fetch_civil_service_jobs(keyword=keyword, location=location)
+        jobs = fetch_civil_service_jobs(keyword=keyword, location=location)
     except Exception:
-        return fetch_fallback_jobs(keyword=keyword, location=location)
+        jobs = fetch_fallback_jobs(keyword=keyword, location=location)
+
+    return jobs[offset: offset + limit]


### PR DESCRIPTION
## Summary
- add `limit` and `offset` query parameters to `/jobs`
- document pagination support in README

## Testing
- `python codex/tasks/test_jobspy_import.py`

------
https://chatgpt.com/codex/tasks/task_e_6845c2e26e5883218994f923cf4151a8